### PR TITLE
checkAll support

### DIFF
--- a/src/components/model/tree-store.js
+++ b/src/components/model/tree-store.js
@@ -327,6 +327,15 @@ export default class TreeStore {
         }
     }
 
+    setCheckedAll(checked = true) {
+      const allNodes = this._getAllNodes();
+
+      for (const node of allNodes) {
+        node.indeterminate = false;
+        node.checked = checked;
+      }
+    }
+
     getCurrentNode() {
         return this.currentNode;
     }

--- a/src/components/ve-tree.vue
+++ b/src/components/ve-tree.vue
@@ -308,6 +308,10 @@ export default {
       this.store.setChecked(data, checked, deep);
     },
 
+    setCheckedAll(checked = true) {
+      this.store.setCheckedAll(checked);
+    },
+
     getHalfCheckedNodes() {
       return this.store.getHalfCheckedNodes();
     },


### PR DESCRIPTION
el-tree中使用`setCheckedNodes`或者`setCheckedKeys`实现全选效率太低了，几万节点需要十几秒，不能忍，，
所以直接加了个全选\取消全选的入口