### PR TITLE
解决虚拟列表拖拽出现问题

### DIFF
--- a/src/components/ve-tree.vue
+++ b/src/components/ve-tree.vue
@@ -484,7 +484,14 @@ export default {
       } catch (e) {
         console.log(e);
       }
-      dragState.draggingNode = treeNode;
+      // dragState.draggingNode = treeNode;
+      if (treeNode) {
+        dragState.draggingNode = {
+          node: treeNode.node
+        };
+      } else {
+        dragState.draggingNode = null
+      }
       this.$emit("node-drag-start", treeNode.node, event);
     });
 


### PR DESCRIPTION
产生原因：拖拽范围超出buffer，导致拖拽的节点被复用